### PR TITLE
Fix duplicate --output_path argument in mesh reconstruction script

### DIFF
--- a/code/mesh_generation_code/reconstruct_mesh.sh
+++ b/code/mesh_generation_code/reconstruct_mesh.sh
@@ -69,6 +69,5 @@ cp $DENSE3D_PATH/fused-minpix$minpix.ply.vis $DENSE3D_PATH/fused.ply.vis
 echo "colmap delaunay_mesher"
 $COLMAP_COMMAND delaunay_mesher \
     --input_path $DENSE3D_PATH \
-    --output_path $DENSE3D_PATH/fused-minpix$minpix-meshed-delaunay-qreg5.ply \
     --output_path $FINAL_MESH_PATH \
     --DelaunayMeshing.quality_regularization 5


### PR DESCRIPTION
This PR removes a redundant --output_path argument from reconstruct_mesh.sh. Now the script only uses the correct output path.

Fixes error:
Duplicate --output_path argument causing an error when running the script.

Testing:
Run reconstruct_mesh.sh and check that the final mesh is created at $FINAL_MESH_PATH without errors about duplicate options.

I hope this is helpful!