### PR TITLE
Fix missing cython module when setting up conda environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -59,6 +59,7 @@ dependencies:
   - cuda-toolkit=11.6.1
   - cuda-tools=11.6.1
   - cuda-visual-tools=11.6.1
+  - cython=3.0.10
   - dash-renderer=0.20.0
   - dataclasses=0.8
   - debugpy=1.6.7
@@ -225,7 +226,6 @@ dependencies:
       - comm==0.1.3
       - contourpy==1.0.7
       - cycler==0.11.0
-      - cython==3.0.10
       - cython-bbox==0.1.5
       - dash==2.6.2
       - dash-core-components==2.0.0


### PR DESCRIPTION
This PR lifts cython from a pip dependency to a conda dependency in the environment.yml file.

Fixes error:
ModuleNotFoundError: No module named 'Cython'
when running `conda env create -n OSNOM -f environment.yml`

Explanation:
Even though cython was specified in the environment.yml file under pip dependencies, it is required by pycocotools (which is also a pip dependency) at build time. By specifying cython under the conda dependencies, it is installed before the pip installs which fixes the issue.

Testing:
Run `conda env create -n OSNOM -f environment.yml` to see no error when creating a new environment.
